### PR TITLE
Allow the eluent and calibrant/suspect tables to be specified directly

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -627,13 +627,15 @@ viscosity <- function(organic,organic_modifier){
 
 #' @export
 add_mobile_phase_composition = function(data,
-                                        path_eluent_file,
+                                        eluent,
                                         organic_modifier = "MeCN",
                                         pH_aq = 7.0) {
-  eluent = read_delim(path_eluent_file,
+  if (is.character(eluent)) {
+    eluent = read_delim(eluent,
                       delim = ",",
                       col_names = TRUE,
                       show_col_types = FALSE)
+  }
   
   ## Joining all collected data to one tibble, removing missing values, calculating slopes ----
   data = data %>%
@@ -963,8 +965,8 @@ SiriusScoreRank1 <- function(subfolder_score, folderwithSIRIUSfiles){
 }
 
 #' @export
-MS2Quant_quantify <- function(path_dataframe_calibrants_suspects,
-                              path_eluent_file,
+MS2Quant_quantify <- function(calibrants_suspects,
+                              eluent,
                               organic_modifier = "MeCN",
                               pH_aq = 2.7,
                               fingerprints = tibble()){
@@ -973,16 +975,18 @@ MS2Quant_quantify <- function(path_dataframe_calibrants_suspects,
   data_list_sirius <- readRDS(system.file("model", "model_MS2Quant_xgbTree_allData.RData", package = "MS2Quant"))
   MS2Quant = data_list_sirius$model
   
+  if (is.character(calibrants_suspects))
+  {
   # read in dataframe with calibrants and suspects
-  dataframe_calibrants_suspects <- read_delim(path_dataframe_calibrants_suspects,
-                                              show_col_types = FALSE)
+      calibrants_suspects <- read_delim(calibrants_suspects, show_col_types = FALSE)
+  }
   
   #############
   # CALIBRATION
   #############
   
   # 1) Find calibration compounds with concentration and area information from the dataframe
-  calibrants <- dataframe_calibrants_suspects %>% 
+  calibrants <- calibrants_suspects %>%
     drop_na(conc_M)
   
   # 2) calculcate response factors (slopes of calibration graphs)
@@ -1010,7 +1014,7 @@ MS2Quant_quantify <- function(path_dataframe_calibrants_suspects,
   
   # 2) Add eluent composition parameters 
   calibrants_structural_FP <- add_mobile_phase_composition(calibrants_structural_FP,
-                                                           path_eluent_file = path_eluent_file,
+                                                           eluent = eluent,
                                                            organic_modifier = organic_modifier,
                                                            pH_aq = pH_aq)
   
@@ -1046,7 +1050,7 @@ MS2Quant_quantify <- function(path_dataframe_calibrants_suspects,
   ##########
   
   # 1) identify the suspects - candidate structures or only area and retention time?
-  suspects <- dataframe_calibrants_suspects %>% 
+  suspects <- calibrants_suspects %>%
     filter(is.na(conc_M))
   
   suspects_with_candidate <- suspects %>% 
@@ -1100,7 +1104,7 @@ MS2Quant_quantify <- function(path_dataframe_calibrants_suspects,
   # 2) Add eluent composition parameters 
   
   suspects_structural_FP <- add_mobile_phase_composition(suspects_structural_FP,
-                                                         path_eluent_file = path_eluent_file,
+                                                         eluent = eluent,
                                                          organic_modifier = organic_modifier,
                                                          pH_aq = pH_aq)
   

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ and some examples can be found on [MS2Tox github page](https://github.com/kruvel
 
 ### 1.5. Use MS2Quant to quantify
 To quantify the unidentified chemicals, *MS2Quant_quantify()* function can be used. Following inputs are neede for the function:
-+ *path_dataframe_calibrants_suspects* - data table including information about calibrants and suspects subject to quantification (see Chapter 1.3.)
-+ *path_eluent_file* - path to a file containing the gradient program information (see example at [inst/example_data/eluent.csv](https://github.com/kruvelab/MS2Quant/blob/main/inst/example_data/eluent.csv))
++ *calibrants_suspects* - (path to) data table including information about calibrants and suspects subject to quantification (see Chapter 1.3.)
++ *eluent* - (path to) the gradient program information (see example at [inst/example_data/eluent.csv](https://github.com/kruvelab/MS2Quant/blob/main/inst/example_data/eluent.csv))
 + *organic_modifier* - specify which organic modifier was used (either "MeCN" or "MeOH").
 + *pH_aq* - specify the pH of the water phase.
 + *fingerprints* - specify the path to your SIRIUS calculations results folder.


### PR DESCRIPTION
These changes allow the eluent and calibrant/suspect data table to be set directly as a data.frame by the user. It is still possible to specify paths to these tables: the code checks if a path is given and then loads the table as before, otherwise the data is directly used. To accommodate these changes the relevant function parameter names are now a bit more generic.