### PR TITLE
De-duplicate calibrant rows

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -915,6 +915,9 @@ MS2Quant_quantify <- function(calibrants_suspects,
     facet_wrap(~ identifier, scales = "free") +
     theme_classic()
 
+  # de-duplicate calibrant rows
+  calibrants <- calibrants %>% distinct(SMILES, identifier, .keep_all = TRUE)
+  
   # 1) Use SMILES of calibrants to calculate structural fingerprints
   calibrants_structural_FP <- Fingerprint_calc(calibrants)
 


### PR DESCRIPTION
Hi Helen,

At the moment the table used to calibrate response factors is not de-duplicated, which means that fingerprints, ionization efficiencies and regression parameters will be repeatedly calculated for each identifier/SMILES combination. This will also influence regression parameters if different numbers of standards were applied to obtain response factors.

The small patch will simply de-duplicate the calibrant table prior to calculations (but after generating the separate plots, so they still work).

Thanks,
Rick